### PR TITLE
Fix parsing comments in `readString` API

### DIFF
--- a/ballerina/modules/composer/state.bal
+++ b/ballerina/modules/composer/state.bal
@@ -36,10 +36,10 @@ public class ComposerState {
     # Flag is set if same map keys are allowed in a mapping
     readonly & boolean allowMapEntryRedefinition;
 
-    public isolated function init(string[] lines, map<schema:YAMLTypeConstructor> tagSchema,
-        boolean allowAnchorRedefinition, boolean allowMapEntryRedefinition, boolean isString = false) returns parser:ParsingError? {
+    public isolated function init(string[]|string yamlInput, map<schema:YAMLTypeConstructor> tagSchema,
+        boolean allowAnchorRedefinition, boolean allowMapEntryRedefinition) returns parser:ParsingError? {
 
-        self.parserState = check new (lines, isString);
+        self.parserState = check new (yamlInput);
         self.tagSchema = tagSchema;
         self.allowAnchorRedefinition = allowAnchorRedefinition;
         self.allowMapEntryRedefinition = allowMapEntryRedefinition;

--- a/ballerina/modules/composer/state.bal
+++ b/ballerina/modules/composer/state.bal
@@ -37,9 +37,9 @@ public class ComposerState {
     readonly & boolean allowMapEntryRedefinition;
 
     public isolated function init(string[] lines, map<schema:YAMLTypeConstructor> tagSchema,
-        boolean allowAnchorRedefinition, boolean allowMapEntryRedefinition) returns parser:ParsingError? {
+        boolean allowAnchorRedefinition, boolean allowMapEntryRedefinition, boolean isString = false) returns parser:ParsingError? {
 
-        self.parserState = check new (lines);
+        self.parserState = check new (lines, isString);
         self.tagSchema = tagSchema;
         self.allowAnchorRedefinition = allowAnchorRedefinition;
         self.allowMapEntryRedefinition = allowMapEntryRedefinition;

--- a/ballerina/modules/parser/parser.bal
+++ b/ballerina/modules/parser/parser.bal
@@ -251,7 +251,7 @@ public isolated function parse(ParserState state, ParserOption option = DEFAULT,
 public isolated function isValidPlanarScalar(string value) returns boolean {
     string? planarScalarResult = ();
     do {   
-        ParserState parserState = check new ([value], true);
+        ParserState parserState = check new (value);
         planarScalarResult = check planarScalar(parserState, false);
     } on fail {
         return false;

--- a/ballerina/modules/parser/parser.bal
+++ b/ballerina/modules/parser/parser.bal
@@ -52,8 +52,7 @@ public isolated function parse(ParserState state, ParserOption option = DEFAULT,
     if state.currentToken.token == lexer:EOL || state.currentToken.token == lexer:EMPTY_LINE
         || state.currentToken.token == lexer:COMMENT {
 
-        if (!state.lexerState.isNewLine && state.lineIndex >= state.numLines - 1) ||
-            (state.lexerState.isNewLine && state.lexerState.isEndOfStream()) {
+        if state.isEndOfFile() {
             if docType == DIRECTIVE_DOCUMENT {
                 return generateExpectError(state, lexer:DIRECTIVE_MARKER, lexer:DIRECTIVE);
             }
@@ -252,7 +251,7 @@ public isolated function parse(ParserState state, ParserOption option = DEFAULT,
 public isolated function isValidPlanarScalar(string value) returns boolean {
     string? planarScalarResult = ();
     do {   
-        ParserState parserState = check new ([value]);
+        ParserState parserState = check new ([value], true);
         planarScalarResult = check planarScalar(parserState, false);
     } on fail {
         return false;

--- a/ballerina/modules/parser/scalar.bal
+++ b/ballerina/modules/parser/scalar.bal
@@ -201,8 +201,7 @@ isolated function planarScalar(ParserState state, boolean allowTokensAsPlanar = 
                 check checkToken(state);
 
                 // Terminate at the end of the line
-                if (!state.lexerState.isNewLine && state.lineIndex >= state.numLines - 1) ||
-                    (state.lexerState.isNewLine && state.lexerState.isEndOfStream()) {
+                if state.isEndOfFile() {
                     break;
                 }
                 check state.initLexer();

--- a/ballerina/modules/parser/state.bal
+++ b/ballerina/modules/parser/state.bal
@@ -17,7 +17,7 @@ import yaml.common;
 
 public class ParserState {
     # Properties for the YAML lines
-    string[] lines;
+    string[]|string yamlInput;
     int numLines;
     int lineIndex = -1;
 
@@ -64,10 +64,10 @@ public class ParserState {
 
     boolean isString;
 
-    public isolated function init(string[] lines, boolean isString = false) returns ParsingError? {
-        self.lines = lines;
-        self.isString = isString;
-        self.numLines = lines.length();
+    public isolated function init(string[]|string yamlInput) returns ParsingError? {
+        self.yamlInput = yamlInput;
+        self.isString = yamlInput is string;
+        self.numLines = self.isString ? 1 : (<string[]>yamlInput).length();
         ParsingError? err = self.initLexer();
         if err is ParsingError {
             self.eventBuffer.push({endType: common:STREAM});
@@ -96,7 +96,7 @@ public class ParserState {
                 line = currentLine.substring(self.lexerState.index);
             } else {
                 if self.lineIndex == 0 {
-                    line = self.lines[0];
+                    line = <string>self.yamlInput;
                 } else {
                     int? index = currentLine.indexOf("\n");
                     if index is int {
@@ -110,7 +110,8 @@ public class ParserState {
             if self.lineIndex >= self.numLines {
                 return generateGrammarError(self, message);
             }
-            line = self.lines[self.lineIndex];
+            string[] lines = <string[]>self.yamlInput;
+            line = lines[self.lineIndex];
         }
 
         self.explicitDoc = false;

--- a/ballerina/modules/parser/state.bal
+++ b/ballerina/modules/parser/state.bal
@@ -62,12 +62,12 @@ public class ParserState {
 
     common:Event[] eventBuffer = [];
 
-    boolean isString;
+    boolean isStringInput;
 
     public isolated function init(string[]|string yamlInput) returns ParsingError? {
         self.yamlInput = yamlInput;
-        self.isString = yamlInput is string;
-        self.numLines = self.isString ? 1 : (<string[]>yamlInput).length();
+        self.isStringInput = yamlInput is string;
+        self.numLines = self.isStringInput ? 1 : (<string[]>yamlInput).length();
         ParsingError? err = self.initLexer();
         if err is ParsingError {
             self.eventBuffer.push({endType: common:STREAM});
@@ -90,7 +90,7 @@ public class ParserState {
         self.lineIndex += 1;
         string line;
 
-        if self.isString {
+        if self.isStringInput {
             string currentLine = self.lexerState.line;
             if self.lexerState.isNewLine {
                 line = currentLine.substring(self.lexerState.index);
@@ -121,5 +121,5 @@ public class ParserState {
     }
 
     isolated function isEndOfFile() returns boolean =>
-        self.isString ? self.lexerState.isEndOfStream() : self.lineIndex >= self.numLines - 1;
+        self.isStringInput ? self.lexerState.isEndOfStream() : self.lineIndex >= self.numLines - 1;
 }

--- a/ballerina/tests/api_test.bal
+++ b/ballerina/tests/api_test.bal
@@ -22,9 +22,11 @@ import ballerina/test;
 }
 function testReadYamlString() returns error? {
     string input = string `
+        # comment
         outer:
           inner: {outer: inner}
         seq:
+          # comment
           - - [[nested, sequence]]
         int: 1
         bool: true

--- a/ballerina/yaml.bal
+++ b/ballerina/yaml.bal
@@ -25,7 +25,7 @@ import yaml.composer;
 public isolated function readString(string yamlString, *ReadConfig config) returns json|Error {
     composer:ComposerState composerState = check new ([yamlString],
         generateTagHandlesMap(config.yamlTypes, config.schema), config.allowAnchorRedefinition,
-        config.allowMapEntryRedefinition);
+        config.allowMapEntryRedefinition, true);
     return composer:composeDocument(composerState);
 }
 

--- a/ballerina/yaml.bal
+++ b/ballerina/yaml.bal
@@ -23,9 +23,9 @@ import yaml.composer;
 # + config - Configuration for reading a YAML file
 # + return - YAML map object on success. Else, returns an error
 public isolated function readString(string yamlString, *ReadConfig config) returns json|Error {
-    composer:ComposerState composerState = check new ([yamlString],
+    composer:ComposerState composerState = check new (yamlString,
         generateTagHandlesMap(config.yamlTypes, config.schema), config.allowAnchorRedefinition,
-        config.allowMapEntryRedefinition, true);
+        config.allowMapEntryRedefinition);
     return composer:composeDocument(composerState);
 }
 


### PR DESCRIPTION
## Purpose
$title as the current implementation of the `readString` does not proceed to the next line once it detects a comment.

Fixes https://github.com/ballerina-platform/ballerina-library/issues/6125

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
