### PR TITLE
Reintegrate Community-Driven Test Suites

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "ballerina/tests/resources"]
+	path = ballerina/tests/resources
+	url = https://github.com/nipunayf/yaml-test-suite
+	branch = data

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "yaml"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Ballerina"]
 keywords = ["yaml"]
 repository = "https://github.com/ballerina-platform/module-ballerina-yaml"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -109,7 +109,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -147,7 +147,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "yaml"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "io"},

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -104,6 +104,15 @@ publishing {
     }
 }
 
+task checkAndUpdateSubmodule {
+    doLast {
+        def initCommand = ['git', 'submodule', 'update', '--init', '--recursive']
+        initCommand.execute(null, projectDir).waitFor()
+        println "Submodule initialized successfully."
+    }
+}
+
+test.dependsOn checkAndUpdateSubmodule
 updateTomlFiles.dependsOn copyStdlibs
 
 build.dependsOn "generatePomFileForMavenPublication"

--- a/ballerina/tests/it.bal
+++ b/ballerina/tests/it.bal
@@ -48,8 +48,7 @@ function initYamlCustomeTypes() {
 }
 
 @test:Config {
-    dataProvider: yamlDataGen,
-    enable: false
+    dataProvider: yamlDataGen
 }
 function testYAMLIntegrationTest(string filePath, json expectedOutput, boolean isStream, boolean isError) returns error? {
     json|Error output = readFile(filePath, yamlTypes = customYamlTypes, isStream = isStream);


### PR DESCRIPTION
## Purpose

This PR aims to reintroduce community-driven test suites into the `ballerina/yaml`. These test suites were previously managed as Git submodules and are critical for ensuring the robustness and reliability of the read APIs provided by these modules. 

Related to: https://github.com/ballerina-platform/ballerina-library/issues/6129

## Examples

N/A - This PR focuses on test suite integration rather than API usage examples.

## Checklist
- [x] Linked to an issue ([#6129](https://github.com/ballerina-platform/ballerina-library/issues/6129))
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec (if applicable)
- [ ] Checked native-image compatibility (if applicable)
