### PR TITLE
Add the integration test suite for the readString API

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "yaml"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Ballerina"]
 keywords = ["yaml"]
 repository = "https://github.com/ballerina-platform/module-ballerina-yaml"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -147,7 +147,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "yaml"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "io"},

--- a/ballerina/modules/common/utils.bal
+++ b/ballerina/modules/common/utils.bal
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ballerina/io;
+
 # Generate an error for conversion fault between Ballerina and YAML.
 #
 # + message - Cause of the error message
@@ -40,3 +42,17 @@ public isolated function processTypeCastingError(json|error value) returns json|
 # + return - Formatted error message as a string
 public isolated function generateExpectedEndEventErrorMessage(string actualEvent, string expectedEvent) returns string
     => string `Expected '-${expectedEvent}' before '-${actualEvent}'`;
+
+# Convert the string to a string array.
+#
+# + inputStr - Input string to be converted
+# + return - String array of the input string
+public isolated function convertStringToLines(string inputStr) returns string[] {
+    do {
+        io:ReadableByteChannel readableChannel = check io:createReadableChannel(inputStr.toBytes());
+        io:ReadableCharacterChannel readableCharChannel = new (readableChannel, io:DEFAULT_ENCODING);
+        return check readableCharChannel.readAllLines();
+    } on fail {
+        return [inputStr];
+    }
+}

--- a/ballerina/modules/common/utils.bal
+++ b/ballerina/modules/common/utils.bal
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ballerina/io;
-
 # Generate an error for conversion fault between Ballerina and YAML.
 #
 # + message - Cause of the error message
@@ -42,17 +40,3 @@ public isolated function processTypeCastingError(json|error value) returns json|
 # + return - Formatted error message as a string
 public isolated function generateExpectedEndEventErrorMessage(string actualEvent, string expectedEvent) returns string
     => string `Expected '-${expectedEvent}' before '-${actualEvent}'`;
-
-# Convert the string to a string array.
-#
-# + inputStr - Input string to be converted
-# + return - String array of the input string
-public isolated function convertStringToLines(string inputStr) returns string[] {
-    do {
-        io:ReadableByteChannel readableChannel = check io:createReadableChannel(inputStr.toBytes());
-        io:ReadableCharacterChannel readableCharChannel = new (readableChannel, io:DEFAULT_ENCODING);
-        return check readableCharChannel.readAllLines();
-    } on fail {
-        return [inputStr];
-    }
-}

--- a/ballerina/modules/composer/state.bal
+++ b/ballerina/modules/composer/state.bal
@@ -36,10 +36,10 @@ public class ComposerState {
     # Flag is set if same map keys are allowed in a mapping
     readonly & boolean allowMapEntryRedefinition;
 
-    public isolated function init(string[]|string yamlInput, map<schema:YAMLTypeConstructor> tagSchema,
+    public isolated function init(string[] lines, map<schema:YAMLTypeConstructor> tagSchema,
         boolean allowAnchorRedefinition, boolean allowMapEntryRedefinition) returns parser:ParsingError? {
 
-        self.parserState = check new (yamlInput);
+        self.parserState = check new (lines);
         self.tagSchema = tagSchema;
         self.allowAnchorRedefinition = allowAnchorRedefinition;
         self.allowMapEntryRedefinition = allowMapEntryRedefinition;

--- a/ballerina/modules/lexer/lexer.bal
+++ b/ballerina/modules/lexer/lexer.bal
@@ -62,12 +62,6 @@ public isolated function scan(LexerState state) returns LexerState|LexicalError 
         return state.index == 0 ? state.tokenize(EMPTY_LINE) : state.tokenize(EOL);
     }
 
-    // Check for line breaks when reading from string
-    if state.peek() == "\n" && state.context != LEXER_DOUBLE_QUOTE {
-        state.isNewLine = true;
-        return state.tokenize(EOL);
-    }
-
     match state.context {
         LEXER_START => {
             return contextStart(state);

--- a/ballerina/modules/lexer/scan.bal
+++ b/ballerina/modules/lexer/scan.bal
@@ -158,7 +158,7 @@ isolated function scanPlanarChar(LexerState state) returns boolean|LexicalError 
     }
 
     // Step back from the white spaces if EOL or ':' is reached 
-    if state.peek() == () || state.peek() == "\n" {
+    if state.peek() == () || state.isNewLine() {
         state.forward(-numWhitespace);
         return true;
     }

--- a/ballerina/modules/lexer/state.bal
+++ b/ballerina/modules/lexer/state.bal
@@ -70,8 +70,6 @@ public class LexerState {
 
     public boolean firstLine = true;
 
-    public boolean isNewLine = false;
-
     int mappingKeyColumn = -1;
 
     # Output YAML token
@@ -150,7 +148,6 @@ public class LexerState {
         self.indentStartIndex = -1;
         self.tokensForMappingValue = [];
         self.tabInWhitespace = -1;
-        self.isNewLine = false;
         self.keyDefinedForLine = false;
     }
 
@@ -167,6 +164,4 @@ public class LexerState {
     }
 
     public isolated function isFlowCollection() returns boolean => self.numOpenedFlowCollections > 0;
-
-    public isolated function isEndOfStream() returns boolean => self.index >= self.line.length();
 }

--- a/ballerina/modules/lexer/state.bal
+++ b/ballerina/modules/lexer/state.bal
@@ -164,4 +164,10 @@ public class LexerState {
     }
 
     public isolated function isFlowCollection() returns boolean => self.numOpenedFlowCollections > 0;
+    
+    # Check if the current character is a new line. 
+    # This should be replaced by the os module once it supports an API: #4931.
+    # 
+    # + return - True if the current character is a new line
+    public isolated function isNewLine() returns boolean => self.peek() == "\n" || self.peek() == "\r\n";
 }

--- a/ballerina/modules/parser/parser.bal
+++ b/ballerina/modules/parser/parser.bal
@@ -250,8 +250,9 @@ public isolated function parse(ParserState state, ParserOption option = DEFAULT,
 # + return - True if the string is a valid planar scalar. Else, false.
 public isolated function isValidPlanarScalar(string value) returns boolean {
     string? planarScalarResult = ();
-    do {   
-        ParserState parserState = check new (value);
+    do {
+        string[] lines = common:convertStringToLines(value);
+        ParserState parserState = check new (lines);
         planarScalarResult = check planarScalar(parserState, false);
     } on fail {
         return false;

--- a/ballerina/modules/parser/parser.bal
+++ b/ballerina/modules/parser/parser.bal
@@ -251,8 +251,7 @@ public isolated function parse(ParserState state, ParserOption option = DEFAULT,
 public isolated function isValidPlanarScalar(string value) returns boolean {
     string? planarScalarResult = ();
     do {
-        string[] lines = common:convertStringToLines(value);
-        ParserState parserState = check new (lines);
+        ParserState parserState = check new ([value]);
         planarScalarResult = check planarScalar(parserState, false);
     } on fail {
         return false;

--- a/ballerina/modules/parser/state.bal
+++ b/ballerina/modules/parser/state.bal
@@ -89,8 +89,7 @@ public class ParserState {
         if self.lineIndex >= self.numLines {
             return generateGrammarError(self, message);
         }
-        string[] lines = <string[]>self.lines;
-        line = lines[self.lineIndex];
+        line = self.lines[self.lineIndex];
 
         self.explicitDoc = false;
         self.expectBlockSequenceValue = false;

--- a/ballerina/tests/api_test.bal
+++ b/ballerina/tests/api_test.bal
@@ -17,8 +17,7 @@ import ballerina/io;
 import ballerina/test;
 
 @test:Config {
-    groups: ["api"],
-    enable: false
+    groups: ["api"]
 }
 function testReadYamlString() returns error? {
     string input = string `
@@ -76,8 +75,7 @@ function testWriteYamlFile() returns error? {
 
 @test:Config {
     dataProvider: yamlSchemaDataGen,
-    groups: ["api"],
-    enable: false
+    groups: ["api"]
 }
 function testReadYAMLSchema(YAMLSchema schema, json expectedOutput) returns error? {
     string input = string `

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -11,8 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 import yaml.schema;
+import yaml.composer;
+
 import ballerina/file;
 
 # Checks if the file exists. If not, creates a new file.
@@ -60,4 +61,16 @@ isolated function generateTagHandlesMap(YamlType[] yamlTypes, YAMLSchema yamlSch
     }
 
     return tagHandles;
+}
+
+# Parses the given lines of YAML and returns the JSON representation.
+#
+# + lines - Lines of the YAML document
+# + config - Configuration for the YAML parser
+# + return - JSON representation of the YAML document
+isolated function readLines(string[] lines, ReadConfig config) returns json|Error {
+    composer:ComposerState composerState = check new (lines, generateTagHandlesMap(config.yamlTypes, config.schema),
+        config.allowAnchorRedefinition, config.allowMapEntryRedefinition
+    );
+    return config.isStream ? composer:composeStream(composerState) : composer:composeDocument(composerState);
 }

--- a/ballerina/yaml.bal
+++ b/ballerina/yaml.bal
@@ -15,7 +15,6 @@
 import ballerina/io;
 import yaml.emitter;
 import yaml.serializer;
-import yaml.common;
 
 # Parses a Ballerina string of YAML content into a Ballerina map object.
 #
@@ -23,7 +22,9 @@ import yaml.common;
 # + config - Configuration for reading a YAML file
 # + return - YAML map object on success. Else, returns an error
 public isolated function readString(string yamlString, *ReadConfig config) returns json|Error {
-    string[] lines = common:convertStringToLines(yamlString);
+    io:ReadableByteChannel readableChannel = check io:createReadableChannel(yamlString.toBytes());
+    io:ReadableCharacterChannel readableCharChannel = new (readableChannel, io:DEFAULT_ENCODING);
+    string[] lines = check readableCharChannel.readAllLines();
     return readLines(lines, config);
 }
 

--- a/ballerina/yaml.bal
+++ b/ballerina/yaml.bal
@@ -15,7 +15,7 @@
 import ballerina/io;
 import yaml.emitter;
 import yaml.serializer;
-import yaml.composer;
+import yaml.common;
 
 # Parses a Ballerina string of YAML content into a Ballerina map object.
 #
@@ -23,10 +23,8 @@ import yaml.composer;
 # + config - Configuration for reading a YAML file
 # + return - YAML map object on success. Else, returns an error
 public isolated function readString(string yamlString, *ReadConfig config) returns json|Error {
-    composer:ComposerState composerState = check new (yamlString,
-        generateTagHandlesMap(config.yamlTypes, config.schema), config.allowAnchorRedefinition,
-        config.allowMapEntryRedefinition);
-    return composer:composeDocument(composerState);
+    string[] lines = common:convertStringToLines(yamlString);
+    return readLines(lines, config);
 }
 
 # Parses a YAML file into a Ballerina json object.
@@ -36,9 +34,7 @@ public isolated function readString(string yamlString, *ReadConfig config) retur
 # + return - YAML map object on success. Else, returns an error
 public isolated function readFile(string filePath, *ReadConfig config) returns json|Error {
     string[] lines = check io:fileReadLines(filePath);
-    composer:ComposerState composerState = check new (lines, generateTagHandlesMap(config.yamlTypes, config.schema),
-        config.allowAnchorRedefinition, config.allowMapEntryRedefinition);
-    return config.isStream ? composer:composeStream(composerState) : composer:composeDocument(composerState);
+    return readLines(lines, config);
 }
 
 # Converts the YAML structure to an array of strings.

--- a/ballerina/yaml.bal
+++ b/ballerina/yaml.bal
@@ -22,9 +22,9 @@ import yaml.serializer;
 # + config - Configuration for reading a YAML file
 # + return - YAML map object on success. Else, returns an error
 public isolated function readString(string yamlString, *ReadConfig config) returns json|Error {
-    io:ReadableByteChannel readableChannel = check io:createReadableChannel(yamlString.toBytes());
-    io:ReadableCharacterChannel readableCharChannel = new (readableChannel, io:DEFAULT_ENCODING);
-    string[] lines = check readableCharChannel.readAllLines();
+    io:ReadableByteChannel byteChannel = check io:createReadableChannel(yamlString.toBytes());
+    io:ReadableCharacterChannel charChannel = new (byteChannel, io:DEFAULT_ENCODING);
+    string[] lines = check charChannel.readAllLines();
     return readLines(lines, config);
 }
 


### PR DESCRIPTION
## Purpose
As a measure to increase the reliability of the readString API, the integration test suite has been used to ensure the robustness of this API. The PR addresses the following points:

1. The API implementations are refactored to follow a uniform path, making the code more readable. 
2. The lexer is modified to support the newline character in Windows.

Fixes https://github.com/ballerina-platform/ballerina-library/issues/6141
Fixes https://github.com/ballerina-platform/ballerina-library/issues/4330
Fixes https://github.com/ballerina-platform/ballerina-library/issues/4325

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
